### PR TITLE
go snapshotter: don't fail when there's no file + no snapshots

### DIFF
--- a/snapshotter/snapshotter.go
+++ b/snapshotter/snapshotter.go
@@ -102,6 +102,11 @@ func (s *Snapshotter) Verify() {
 		}
 
 	} else {
+		// When no snapshots file exists and no snapshots have been taken, do nothing.
+		if _, err := os.Stat(name); os.IsNotExist(err) && len(s.snapshots) == 0 {
+			return
+		}
+
 		bytes, err := ioutil.ReadFile(name)
 		if err != nil {
 			s.t.Errorf("error reading snapshots: %s", err)

--- a/snapshotter/snapshotter_test.go
+++ b/snapshotter/snapshotter_test.go
@@ -42,3 +42,8 @@ func TestSnapshotterFailed(t *testing.T) {
 		t.Errorf("expected error, got %v", m.errors)
 	}
 }
+
+func TestSnapshotterNoSnapshots(t *testing.T) {
+	ss := snapshotter.New(t)
+	ss.Verify()
+}


### PR DESCRIPTION
In order to be able to call snapshotter.Verify regardless of whether any snapshots were run and not have empty snapshotter files written, I've added a condition where we skip the comparison when the file doesn't exist and no snapshots have been run.

Edge-case:
If you renamed a test _and_ made snapshots no-ops in the same commit, this wouldn't catch the issue. I'm ok with this.