### PR TITLE
Support go1.13 style unwrapping

### DIFF
--- a/oops/oops.go
+++ b/oops/oops.go
@@ -140,7 +140,12 @@ func Frames(err error) [][]Frame {
 // writeStackTrace unwinds a chain of oopsErrors and prints the stacktrace
 // annotated with explanatory messages.
 func (e *oopsError) writeStackTrace(w io.Writer) {
-	fmt.Fprintf(w, "%s\n\n", e.inner.Error())
+	var base error
+	for err := error(e); err != nil; err = Unwrap(err) {
+		base = err
+	}
+
+	fmt.Fprintf(w, "%s\n\n", base.Error())
 
 	for i, stack := range Frames(e) {
 		// Include a newline between stacks.

--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -95,13 +95,20 @@ func (e *baseErr) Error() string {
 	return "base"
 }
 
-func chain() error {
+func oopsChain() error {
 	base := &baseErr{}
 	a := oops.Wrapf(base, "a")
 	b := oops.Wrapf(a, "b")
 	middle := &wrapperErr{inner: b}
 	c := oops.Wrapf(middle, "c")
 	return oops.Wrapf(c, "d")
+}
+
+func chain() error {
+	base := &baseErr{}
+	a := oops.Wrapf(base, "a")
+	b := oops.Wrapf(a, "b")
+	return &wrapperErr{inner: b}
 }
 
 func TestRecoverNil(t *testing.T) {
@@ -399,18 +406,32 @@ testing.tRunner
 		},
 		{
 			Title: "chain oops",
-			Error: chain(),
+			Error: oopsChain(),
 			Short: "wrapper",
-			Verbose: `wrapper
+			Verbose: `base
 
-github.com/samsarahq/go/oops_test.chain: c
+github.com/samsarahq/go/oops_test.oopsChain: a
 	github.com/samsarahq/go/oops/oops_test.go:123
 github.com/samsarahq/go/oops_test.TestErrors
 	github.com/samsarahq/go/oops/oops_test.go:123
 testing.tRunner
 	testing/testing.go:123
 
-github.com/samsarahq/go/oops_test.chain: d
+github.com/samsarahq/go/oops_test.oopsChain: b
+	github.com/samsarahq/go/oops/oops_test.go:123
+github.com/samsarahq/go/oops_test.TestErrors
+	github.com/samsarahq/go/oops/oops_test.go:123
+testing.tRunner
+	testing/testing.go:123
+
+github.com/samsarahq/go/oops_test.oopsChain: c
+	github.com/samsarahq/go/oops/oops_test.go:123
+github.com/samsarahq/go/oops_test.TestErrors
+	github.com/samsarahq/go/oops/oops_test.go:123
+testing.tRunner
+	testing/testing.go:123
+
+github.com/samsarahq/go/oops_test.oopsChain: d
 	github.com/samsarahq/go/oops/oops_test.go:123
 github.com/samsarahq/go/oops_test.TestErrors
 	github.com/samsarahq/go/oops/oops_test.go:123
@@ -439,6 +460,31 @@ testing.tRunner
 	}
 }
 
+func TestFrames(t *testing.T) {
+	testCases := []struct {
+		description string
+		err         error
+		expected    [][]oops.Frame
+	}{
+		{
+			description: "non-oops chain",
+			err:         chain(),
+			expected:    [][]oops.Frame{[]oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 109, Reason: "a"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 471, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}, []oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 110, Reason: "b"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 471, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}},
+		},
+		{
+			description: "oops chain",
+			err:         oopsChain(),
+			expected:    [][]oops.Frame{[]oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 100, Reason: "a"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 476, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}, []oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 101, Reason: "b"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 476, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}, []oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 103, Reason: "c"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 476, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}, []oops.Frame{oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 104, Reason: "d"}, oops.Frame{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 476, Reason: ""}, oops.Frame{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""}}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, oops.Frames(tc.err))
+		})
+	}
+}
+
 func TestCause(t *testing.T) {
 	base := &baseErr{}
 	a := oops.Wrapf(base, "a")
@@ -454,4 +500,44 @@ func TestCause(t *testing.T) {
 	assert.Equal(t, middle, oops.Cause(middle))
 	assert.Equal(t, middle, oops.Cause(c))
 	assert.Equal(t, middle, oops.Cause(d))
+}
+
+func TestIs(t *testing.T) {
+	base := errors.New("base")
+	a := oops.Wrapf(base, "a")
+	b := oops.Wrapf(a, "b")
+	middle := &wrapperErr{inner: b}
+	c := oops.Wrapf(middle, "c")
+	d := oops.Wrapf(c, "d")
+
+	assert.True(t, oops.Is(a, base))
+	assert.True(t, oops.Is(b, base))
+	assert.True(t, oops.Is(middle, base))
+	assert.True(t, oops.Is(c, base))
+	assert.True(t, oops.Is(d, base))
+}
+
+func TestAs(t *testing.T) {
+	base := &baseErr{}
+	a := oops.Wrapf(base, "a")
+	b := oops.Wrapf(a, "b")
+	middle := &wrapperErr{inner: b}
+	c := oops.Wrapf(middle, "c")
+	d := oops.Wrapf(c, "d")
+
+	var checkBase *baseErr
+	assert.True(t, oops.As(a, &checkBase))
+	assert.Equal(t, base, checkBase)
+
+	checkBase = nil
+	assert.True(t, oops.As(b, &checkBase))
+	assert.Equal(t, base, checkBase)
+
+	var checkWrapper *wrapperErr
+	assert.True(t, oops.As(c, &checkWrapper))
+	assert.Equal(t, middle, checkWrapper)
+
+	checkWrapper = nil
+	assert.True(t, oops.As(d, &checkWrapper))
+	assert.Equal(t, middle, checkWrapper)
 }

--- a/oops/xerrors.go
+++ b/oops/xerrors.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2019 The Go Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package oops
+
+import "reflect"
+
+// A Wrapper provides context around another error.
+type Wrapper interface {
+	// Unwrap returns the next error in the error chain.
+	// If there is no next error, Unwrap returns nil.
+	Unwrap() error
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err implements
+// Unwrap. Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	u, ok := err.(Wrapper)
+	if !ok {
+		return nil
+	}
+	return u.Unwrap()
+}
+
+// Is reports whether any error in err's chain matches target.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool {
+	if target == nil {
+		return err == target
+	}
+	for {
+		if err == target {
+			return true
+		}
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}
+
+// As finds the first error in err's chain that matches the type to which target
+// points, and if so, sets the target to its value and returns true. An error
+// matches a type if it is assignable to the target type, or if it has a method
+// As(interface{}) bool such that As(target) returns true. As will panic if target
+// is not a non-nil pointer to a type which implements error or is of interface type.
+//
+// The As method should set the target to its value and return true if err
+// matches the type to which target points.
+func As(err error, target interface{}) bool {
+	if target == nil {
+		panic("errors: target cannot be nil")
+	}
+	val := reflect.ValueOf(target)
+	typ := val.Type()
+	if typ.Kind() != reflect.Ptr || val.IsNil() {
+		panic("errors: target must be a non-nil pointer")
+	}
+	if e := typ.Elem(); e.Kind() != reflect.Interface && !e.Implements(errorType) {
+		panic("errors: *target must be interface or implement error")
+	}
+	targetType := typ.Elem()
+	for err != nil {
+		if reflect.TypeOf(err).AssignableTo(targetType) {
+			val.Elem().Set(reflect.ValueOf(err))
+			return true
+		}
+		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+			return true
+		}
+		err = Unwrap(err)
+	}
+	return false
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()


### PR DESCRIPTION
This PR:
- Retains backwards compatibility for `oops.Cause` behavior
- Changes the stacktrace behavior to look beyond non-oops boundaries
- Adds [go1.13-style](https://samsara-net.slack.com/archives/CA26TJWKF/p1557174319045800) draft additions for `oops.Is`, `oops.As`, and `oops.Unwrap`.

In a chain that looks like:
```
 oops ──────▶ oops ──────▶ graphql.pathError ──────▶ oops ──────▶ oops ───────▶ sql.ErrNoRows
```
The "previous" field path follows stacktrace information only. Its chain is only useful for pulling out Frames.
```
   ┌ ─previous ─                                       ┌ ─previous ─
                │                                                   │
   │            ▼                                      │            ▼

 oops ──────▶ oops ──────▶ graphql.pathError ──────▶ oops ──────▶ oops ───────▶ sql.ErrNoRows

                │                                      ▲
                                                       │
                └ ─ ─ ─ ─ ─ ─ ─ previous─ ─ ─ ─ ─ ─ ─ ─
```

The inner/cause chain skips intermediary oops-errors and points to the next non-oops error in the chain:
```
   ┌ ─ ─ ─ ─ ─ ─inner─ ─ ─ ─ ─ ─ ─ ┐                   ┌ ─ ─ ─ ─ ─ ─ inner ─ ─ ─ ─ ─ ─
                                                                                      │
   │                               ▼                   │                              ▼

 oops ──────▶ oops ──────▶ graphql.pathError ──────▶ oops ──────▶ oops ───────▶ sql.ErrNoRows

                │                  ▲                                │                 ▲
                                   │
                └ ─ ─ ─inner─ ─ ─ ─                                 └ ─ ─ ─inner─ ─ ─ ┘
```

As before, Cause() will follow inner, retaining backwards compatibility by not following past
non-oops parts of the chain. Instead of changing the logical behavior of `Cause()`, we introduce and promote `Is` and `As` from the [go1.13 error proposal](https://go.googlesource.com/proposal/+/master/design/29934-error-values.md) as a replacement API.

On the otherhand, the stacktrace behavior for previous is not backwards compatible because
it will keep following traces beyond the non-oops boundary. I think this is okay because
application logic isn't likely to depend on what the shape of the stacktrace is - it is purely
for human consumption.
