### PR TITLE
oops: stub out with basic implementation to support gopherjs

### DIFF
--- a/oops/oops.go
+++ b/oops/oops.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package oops
 
 import (
@@ -45,15 +47,6 @@ func (err *oopsError) Unwrap() error {
 		return err.inner
 	}
 	return nil
-}
-
-// A Frame represents a Frame in an oops callstack. The Reason is the manual
-// annotation passed to oops.Wrapf.
-type Frame struct {
-	File     string
-	Function string
-	Line     int
-	Reason   string
 }
 
 type stackWithReasons struct {

--- a/oops/oops_js.go
+++ b/oops/oops_js.go
@@ -1,0 +1,49 @@
+// +build js
+
+package oops
+
+import (
+	"errors"
+	"fmt"
+)
+
+// A Wrapper provides context around another error.
+type Wrapper interface {
+	// Unwrap returns the next error in the error chain.
+	// If there is no next error, Unwrap returns nil.
+	Unwrap() error
+}
+
+func Frames(err error) [][]Frame {
+	return nil
+}
+
+var Errorf = fmt.Errorf
+
+func Wrapf(err error, format string, a ...interface{}) error {
+	return err
+}
+
+func Cause(err error) error {
+	return err
+}
+
+func Recover(p interface{}) error {
+	if p == nil {
+		return nil
+	}
+
+	return errors.New("recovered panic")
+}
+
+func Unwrap(err error) error {
+	return err
+}
+
+func Is(err, target error) bool {
+	panic("Not supported for js builds")
+}
+
+func As(err error, target interface{}) bool {
+	panic("Not supported for js builds")
+}

--- a/oops/types.go
+++ b/oops/types.go
@@ -1,0 +1,12 @@
+package oops
+
+// This file is for exported types
+
+// A Frame represents a Frame in an oops callstack. The Reason is the manual
+// annotation passed to oops.Wrapf.
+type Frame struct {
+	File     string
+	Function string
+	Line     int
+	Reason   string
+}

--- a/oops/xerrors.go
+++ b/oops/xerrors.go
@@ -1,3 +1,4 @@
+// +build !js
 // Copyright (c) 2019 The Go Authors. All rights reserved.
 
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
gopherize doesn't handle the reflect package very well. We want to use oops everywhere so we're opting to provide a basic stub for gopherjs builds.