### PR TITLE
oops: adding function to drop frames from the stack

### DIFF
--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -541,3 +541,28 @@ func TestAs(t *testing.T) {
 	assert.True(t, oops.As(d, &checkWrapper))
 	assert.Equal(t, middle, checkWrapper)
 }
+
+func TestOopsSkipFrame(t *testing.T) {
+	err := getTestError().(*oopsError)
+	newErr := SkipFrames(err, 1).(*oopsError)
+	assert.Equal(t, err.stack.frames[1:], newErr.stack.frames)
+}
+
+func TestOopsSkipFrameWithInvalidInput(t *testing.T) {
+	err := getTestError().(*oopsError)
+	newErr := SkipFrames(err, -1).(*oopsError)
+	newErr1 := SkipFrames(err, 0).(*oopsError)
+	assert.Equal(t, err.stack.frames, newErr.stack.frames)
+	assert.Equal(t, err.stack.frames, newErr1.stack.frames)
+}
+
+func TestOopsSkipMoreFramesThanExists(t *testing.T) {
+	err := getTestError().(*oopsError)
+	newErr := SkipFrames(err, 10000).(*oopsError)
+	assert.Equal(t, err.stack.frames, newErr.stack.frames)
+}
+
+func getTestError() error {
+	return Errorf("test")
+}
+


### PR DESCRIPTION
Adding function to drop stack frames. This can be useful so we don't include wrapper functions in the stack trace 
Example:
```
func Error(c codes.Code, msg string) error {
	err := oops.Wrapf(status.Error(c, msg), msg)
	return oops.DropStackFrames(err, 1)
}
```