### PR TITLE
go oops: Don't unwrap errors beyond oops wrapping

### DIFF
--- a/oops/oops.go
+++ b/oops/oops.go
@@ -197,6 +197,7 @@ func SkipFrames(err error, numFrames int) error {
 // annotated with explanatory messages.
 func (e *oopsError) writeStackTrace(w io.Writer) {
 	var base error
+	var fallbackBase error
 	for err := error(e); err != nil; err = Unwrap(err) {
 		if _, ok := err.(*oopsError); ok {
 			// We've found another oops error in the chain, our "base" is no longer valid.
@@ -211,6 +212,12 @@ func (e *oopsError) writeStackTrace(w io.Writer) {
 			// we want to mark the "base" as networkErr (not realErr)
 			base = err
 		}
+		fallbackBase = err
+	}
+	if base == nil {
+		// This code probably shouldn't be necessary as long as oops errors can't
+		// be at the end of the chain (I'm paranoid).
+		base = fallbackBase
 	}
 
 	fmt.Fprintf(w, "%s\n\n", base.Error())


### PR DESCRIPTION
Summary: Noticed this while debugging some networking errors.  Some of the
main go libraries will wrap errors with extra information similar to oops
wrapping.  These errors will implement the `Unwrap` interface we use to find
the "base" error for when we print oops stack trace logs.  Our existing
unwrapping code will remove all the extra context around the error and
return only the innermost error.

This results in errors like this [net.OpError](https://github.com/golang/go/blob/master/src/net/net.go#L462):

``` 
write udp 192.168.0.1:49380->255.255.255.255:3702: sendto: can't assign requested address
```

being reduced to:

```
can't assign requested address
```

which has removed most of the context around the error, making it much more
difficult to debug.

This code modifies the unwrapping code so that the "base" error will be the
first error node that does not wrap an oopsError.