### PR TITLE
snapshotter: support env var to specify rewrite as well as flag

### DIFF
--- a/snapshotter/README.md
+++ b/snapshotter/README.md
@@ -19,7 +19,8 @@ will fail, because the snapshot isn't there yet, with an error like
 --- FAIL: TestSnapshotter (0.00s)
     snapshotter.go:89: error reading snapshots: open testdata/TestSnapshotter.snapshots.json: no such file or directory
 ```
-To generate the snapshots, run `go test . -rewriteSnapshots`. This generates
+To generate the snapshots, run `go test . -rewriteSnapshots` 
+or run `REWRITE_SNAPSHOTS=1 go test .`. This generates
 a set of snapshots files in the testdata directory that should be added to git.
 Then, the tests will pass. If it at some point a regression causes the test
 output to break, the snapshotter will catch the changes and fail:

--- a/snapshotter/snapshotter.go
+++ b/snapshotter/snapshotter.go
@@ -18,7 +18,12 @@ type T interface {
 	Helper()
 }
 
-var rewrite = flag.Bool("rewriteSnapshots", false, "rewrite test data output")
+var rewriteFlag = flag.Bool("rewriteSnapshots", false, "rewrite test data output")
+
+func isRewrite() bool {
+	rewriteEnvVar := os.Getenv("REWRITE_SNAPSHOTS") == "1"
+	return rewriteEnvVar || *rewriteFlag
+}
 
 func jsonRoundTrip(value interface{}) (interface{}, error) {
 	bytes, err := json.Marshal(value)
@@ -86,7 +91,7 @@ func (s *Snapshotter) Verify() {
 		nameSuffix = "_" + strings.Replace(strings.Replace(s.name, "/", "-", -1), ":", "-", -1)
 	}
 	name := filepath.Join("testdata", strings.Replace(strings.Replace(s.t.Name(), "/", "-", -1), ":", "-", -1)+nameSuffix+".snapshots.json")
-	if *rewrite {
+	if isRewrite() {
 		// If there are no snapshots, then when rewriting, we want to remove the file if it exists.
 		if len(s.snapshots) == 0 {
 			if _, err := os.Stat(name); os.IsNotExist(err) {


### PR DESCRIPTION
When using gotestsum, it doesn't easily allow us to add in custom go test
cli flags. As such, we want to be able to specify the rewrite functionality
via env var as well.