### PR TITLE
oops: Accumulate stacktrace strings using strings.Builder 

### DIFF
--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -679,3 +679,63 @@ testing.tRunner
 		})
 	}
 }
+
+func BenchmarkErrorf(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		oops.Errorf("boom goes the dynamite")
+	}
+}
+
+
+func BenchmarkWrapf(b *testing.B) {
+	benchmarkCases := []struct{
+		name string
+		err error
+	}{
+		{
+			name: "nil error",
+		},
+		{
+			name: "non-oops error",
+			err: errors.New("not great, bob!"),
+		},
+		{
+			name: "direct oops error",
+			err: oops.Errorf("scusi"),
+		},
+		{
+			name: "nested oops error",
+			err: oops.Wrapf(oops.Errorf("scusi"), "mea culpa"),
+		},
+		{
+			name: "triply nested oops error",
+			err: oops.Wrapf(oops.Wrapf(oops.Errorf("scusi"), "mea culpa"), "did i do that"),
+		},
+	}
+
+
+	b.ResetTimer()
+	for _, bc := range benchmarkCases {
+		b.Run(bc.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				oops.Wrapf(bc.err, "boom goes the dynamite")
+			}
+		})
+	}
+}
+
+func BenchmarkOopsErrorError(b *testing.B) {
+	err := oops.Errorf("boom goes the dynamite")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err.Error()
+	}
+}
+
+func BenchmarkMainStackToString(b *testing.B) {
+	err := oops.Errorf("boom goes the dynamite")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		oops.MainStackToString(err)
+	}
+}


### PR DESCRIPTION
By using a strings.Builder instead of an io.Writer, we're able to save time and allocations when accumulating stacktrace strings in (*oopsError).Error and MainStackToString.

```
name                  old time/op    new time/op    delta
OopsErrorError-16       2.38µs ± 0%    1.60µs ± 0%  -32.85%  (p=0.008 n=5+5)
MainStackToString-16    2.50µs ± 0%    1.69µs ± 0%  -32.58%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
OopsErrorError-16       1.82kB ± 0%    1.46kB ± 0%  -20.16%  (p=0.008 n=5+5)
MainStackToString-16    1.83kB ± 0%    1.47kB ± 0%  -20.08%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
OopsErrorError-16         19.0 ± 0%      12.0 ± 0%  -36.84%  (p=0.008 n=5+5)
MainStackToString-16      20.0 ± 0%      13.0 ± 0%  -35.00%  (p=0.008 n=5+5)
```

These savings should apply in any codepath which prints or logs oops errors.

The existing oops tests pass with this change, though I had to [update the expected stack frames and traces](https://gist.github.com/evnm/dfb53f1e7f77cd8209dce29d454bb1fb) to get the tests to pass to begin with. It looks like the tests aren't portable, since they expect particular file locations and line numbers.