### PR TITLE
CI: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+---
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,11 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
👋 This adds a very basic MVP GitHub Actions-based CI workflow that runs all tests (via `go test ./...` from the project root) on each `git push` against the repository, as well as each PR opened against the repository.

It appears the tests currently fail (I can reproduce this locally as well); an example CI run can be viewed here, at my fork: https://github.com/mdb/go/actions/runs/5223060874. 

Is this helpful?