### PR TITLE
docs: clean up whitespace and grammar

### DIFF
--- a/oops/README.md
+++ b/oops/README.md
@@ -1,3 +1,5 @@
-Package oops adds detailed stacktraces to your Go errors. 
+# oops
 
-See https://godoc.org/github.com/samsarahq/go/oops.
+Package oops adds detailed stacktraces to your Go errors.
+
+See [godoc.org/github.com/samsarahq/go/oops](https://godoc.org/github.com/samsarahq/go/oops).

--- a/oops/doc.go
+++ b/oops/doc.go
@@ -1,28 +1,29 @@
 // Package oops adds detailed stacktraces to your Go errors.
 //
-// To use the oops package, calls oops.Errorf when creating a new error, and
+// To use the oops package, call oops.Errorf when creating a new error, and
 // oops.Wrapf when returning nested errors. To access the original error, use
 // oops.Cause. Each function in the callstack can add extra debugging
 // information to help you track down errors.
 //
 // An example error (from the program below) looks as follows:
-//   20 is too large!
 //
-//   main.Foo
-//     github.com/samsarahq/go/oops/example/main.go:12
-//   main.Legacy
-//     github.com/samsarahq/go/oops/example/main.go:19
-//   main.Bar: Legacy(20) didn't work
-//     github.com/samsarahq/go/oops/example/main.go:24
-//   main.Go.func1
-//     github.com/samsarahq/go/oops/example/main.go:35
+//	20 is too large!
 //
-//   main.Go: goroutine had a problem
-//     github.com/samsarahq/go/oops/example/main.go:38
-//   main.main
-//     github.com/samsarahq/go/oops/example/main.go:42
-//   runtime.main
-//     runtime/proc.go:185
+//	main.Foo
+//	  github.com/samsarahq/go/oops/example/main.go:12
+//	main.Legacy
+//	  github.com/samsarahq/go/oops/example/main.go:19
+//	main.Bar: Legacy(20) didn't work
+//	  github.com/samsarahq/go/oops/example/main.go:24
+//	main.Go.func1
+//	  github.com/samsarahq/go/oops/example/main.go:35
+//
+//	main.Go: goroutine had a problem
+//	  github.com/samsarahq/go/oops/example/main.go:38
+//	main.main
+//	  github.com/samsarahq/go/oops/example/main.go:42
+//	runtime.main
+//	  runtime/proc.go:185
 //
 // The first time oops.Errorf or oops.Wrapf is called, it captures a
 // stacktrace. To keep your stacktraces as detailed as possible, it is best to
@@ -36,49 +37,50 @@
 // well!
 //
 // Usage:
-//   package main
 //
-//   import (
-//     "fmt"
+//	package main
 //
-//     "github.com/samsarahq/go/oops"
-//   )
+//	import (
+//	  "fmt"
 //
-//   // Foo creates new errors using oops.Errorf.
-//   func Foo(i int) error {
-//     if i > 10 {
-//       return oops.Errorf("%d is too large!", i)
-//     }
-//     return nil
-//   }
+//	  "github.com/samsarahq/go/oops"
+//	)
 //
-//   // Legacy is old code that does not use oops.
-//   func Legacy(i int) error {
-//     return Foo(i)
-//   }
+//	// Foo creates new errors using oops.Errorf.
+//	func Foo(i int) error {
+//	  if i > 10 {
+//	    return oops.Errorf("%d is too large!", i)
+//	  }
+//	  return nil
+//	}
 //
-//   // Bar wraps errors using Wrapf.
-//   func Bar() error {
-//     if err := Legacy(20); err != nil {
-//       return oops.Wrapf(err, "Legacy(20) didn't work")
-//     }
-//     return nil
-//   }
+//	// Legacy is old code that does not use oops.
+//	func Legacy(i int) error {
+//	  return Foo(i)
+//	}
 //
-//   // Go wraps errors using Wrapf after receiving one from a channel!
-//   func Go() error {
-//     ch := make(chan error)
+//	// Bar wraps errors using Wrapf.
+//	func Bar() error {
+//	  if err := Legacy(20); err != nil {
+//	    return oops.Wrapf(err, "Legacy(20) didn't work")
+//	  }
+//	  return nil
+//	}
 //
-//     go func() {
-//       ch <- Bar()
-//     }()
+//	// Go wraps errors using Wrapf after receiving one from a channel!
+//	func Go() error {
+//	  ch := make(chan error)
 //
-//     return oops.Wrapf(<-ch, "goroutine had a problem")
-//   }
+//	  go func() {
+//	    ch <- Bar()
+//	  }()
 //
-//   func main() {
-//     if err := Go(); err != nil {
-//       fmt.Print(err)
-//     }
-//   }
+//	  return oops.Wrapf(<-ch, "goroutine had a problem")
+//	}
+//
+//	func main() {
+//	  if err := Go(); err != nil {
+//	    fmt.Print(err)
+//	  }
+//	}
 package oops

--- a/oops/oops.go
+++ b/oops/oops.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package oops
@@ -53,26 +54,26 @@ type stack struct {
 type oopsError struct {
 	// inner is the next non-oops error in the chain.
 	inner error
-	// The previous oopsError, if any. This value is only used to follow stacktraces.
+	// previous is the previous oopsError, if any. This value is only used to follow stacktraces.
 	previous *oopsError
-	// The current stacktrace. Might be the same as previous' stacktrace if that
+	// stack is the current stacktrace. Might be the same as previous' stacktrace if that
 	// is another oopsError.
 	stack *stack
-	// A small explanatory message what went wrong at this level in the stack.
+	// reason is a short explanatory message indicating what went wrong at this level in the stack.
 	reason string
-	// The index of the stack frame where this oopsError was added.
+	// index is the index of the stack frame where this oopsError was added.
 	index int
 }
 
-// Error implements error, and outputs a full backtrace.
+// Error implements error and outputs a full backtrace.
 func (e *oopsError) Error() string {
 	var b strings.Builder
 	e.writeStackTrace(&b)
 	return b.String()
 }
 
-// MainStackToString will write the frames of the main goroutine to a string.
-// This will return an empty string if the error is not an oopsError.
+// MainStackToString writes the frames of the main goroutine to a string.
+// It returns an empty string if the error is not an oopsError.
 func MainStackToString(err error) string {
 	var e *oopsError
 	if ok := As(err, &e); !ok {
@@ -372,7 +373,7 @@ func wrapf(err error, reason string) error {
 		//
 		// When parent calls Wrapf and captures the stack frame, the program
 		// counter in child will point the if statement that checks the parent's
-		// return value. When the child then calls Wrapf, it's program counter
+		// return value. When the child then calls Wrapf, its program counter
 		// will have advanced to the Wrapf call, and will no longer match the
 		// program originally captured by the parent. However, the program counter
 		// in compare will still match, and so we compare against that.

--- a/oops/oops_js.go
+++ b/oops/oops_js.go
@@ -1,3 +1,4 @@
+//go:build js
 // +build js
 
 package oops

--- a/oops/types.go
+++ b/oops/types.go
@@ -2,11 +2,11 @@ package oops
 
 // This file is for exported types
 
-// A Frame represents a Frame in an oops callstack. The Reason is the manual
-// annotation passed to oops.Wrapf.
+// Frame represents a Frame in an oops callstack.
 type Frame struct {
 	File     string
 	Function string
 	Line     int
-	Reason   string
+	// Reason is the manual annotation passed to oops.Wrapf.
+	Reason string
 }

--- a/oops/xerrors.go
+++ b/oops/xerrors.go
@@ -1,4 +1,6 @@
+//go:build !js
 // +build !js
+
 // Copyright (c) 2019 The Go Authors. All rights reserved.
 
 // Redistribution and use in source and binary forms, with or without

--- a/snapshotter/README.md
+++ b/snapshotter/README.md
@@ -4,6 +4,7 @@ Snapshotter makes it easy to write tests that verify complex test output. To
 write a snapshot test, make a `testhelpers.Snapshotter` at the beginning of
 the test, set up a call to `Verify()` and call `Snapshot(name, value)`
 whenever you want to test a complex output. For example:
+
 ```go
 func TestWithComplexOutput(t *testing.T) {
     snapshotter := snapshotter.New(t)
@@ -13,17 +14,20 @@ func TestWithComplexOutput(t *testing.T) {
     snapshotter.Snapshot("complicated", output)
 }
 ```
+
 After writing the test, you can run it using `go test .`. However, the test
 will fail, because the snapshot isn't there yet, with an error like
+
 ```
 --- FAIL: TestSnapshotter (0.00s)
     snapshotter.go:89: error reading snapshots: open testdata/TestSnapshotter.snapshots.json: no such file or directory
 ```
-To generate the snapshots, run `go test . -rewriteSnapshots` 
+To generate the snapshots, run `go test . -rewriteSnapshots`
 or run `REWRITE_SNAPSHOTS=1 go test .`. This generates
 a set of snapshots files in the testdata directory that should be added to git.
 Then, the tests will pass. If it at some point a regression causes the test
 output to break, the snapshotter will catch the changes and fail:
+
 ```
 --- FAIL: TestSnapshotter (0.00s)
     snapshotter.go:116: snapshot second differs:
@@ -35,6 +39,5 @@ output to break, the snapshotter will catch the changes and fail:
           },
          ]
 ```
+
 Happy testing!
-
-


### PR DESCRIPTION
* remove trailing whitespace
* use consistent verb tense
* consistently use Godoc-style comments
* correct example code formatting in documentation