### PR TITLE
WIP: Add support to capture multiple errors with stacktraces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+---
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Test
+        run: go test ./...

--- a/oops/oops.go
+++ b/oops/oops.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package oops
@@ -468,4 +469,49 @@ func Recover(p interface{}) error {
 		return wrapf(err, "recovered panic")
 	}
 	return wrapf(fmt.Errorf("recovered panic: %v", p), "")
+}
+
+type MultiError struct {
+	errors []error
+}
+
+func (omr *MultiError) Error() string {
+	return ""
+}
+
+func Errors(err error) []error {
+	if omr, ok := err.(*MultiError); ok {
+		return omr.errors
+	}
+	return []error{err}
+}
+
+func (omr *MultiError) Errors() []error {
+	return omr.errors
+}
+
+func Append(left error, right error) error {
+	if left == nil && right == nil {
+		return nil
+	}
+
+	if right != nil {
+
+	}
+
+	vls := []error{left, right}
+	res := []error{}
+
+	for i := range vls {
+		if vls[i] != nil {
+
+			if merr, ok := right.(*MultiError); ok {
+				vls = append(vls, merr.errors...)
+			}
+
+			res = append(res, wrapf(vls[i], vls[i].Error()))
+		}
+	}
+
+	return &MultiError{errors: res}
 }

--- a/oops/oops.go
+++ b/oops/oops.go
@@ -495,23 +495,18 @@ func Append(left error, right error) error {
 		return nil
 	}
 
-	if right != nil {
+	var errs []error
 
-	}
-
-	vls := []error{left, right}
-	res := []error{}
-
-	for i := range vls {
-		if vls[i] != nil {
-
-			if merr, ok := right.(*MultiError); ok {
-				vls = append(vls, merr.errors...)
+	// potentially unpack arguments if either is a MultiError itself
+	for _, arg := range []error{left, right} {
+		if mErr, ok := arg.(*MultiError); ok {
+			errs = append(errs, mErr.errors...)
+		} else {
+			if arg != nil {
+				errs = append(errs, wrapf(arg, arg.Error()))
 			}
-
-			res = append(res, wrapf(vls[i], vls[i].Error()))
 		}
 	}
 
-	return &MultiError{errors: res}
+	return &MultiError{errors: errs}
 }

--- a/oops/oops.go
+++ b/oops/oops.go
@@ -492,7 +492,7 @@ func (omr *multiError) Error() string {
 	return b.String()
 }
 
-// Return the slice of errors contained within a MultiError instance, or a slice containing
+// Errors returns the slice of errors contained within a multiError instance, or a slice containing
 // the passed error if the argument is a single error
 func Errors(err error) []error {
 	if omr, ok := err.(*multiError); ok {

--- a/oops/oops.go
+++ b/oops/oops.go
@@ -505,7 +505,7 @@ func (omr *multiError) Errors() []error {
 	return omr.errors
 }
 
-// Concatentate an error with another, yielding a MultiError instance
+// Append concatenates an error onto another, yielding a multiError instance
 // containing both errors. If either argument is itself a multierror, then
 // it will be flattened before the contents of the second argument is appended
 func Append(left error, right error) error {

--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -988,7 +988,7 @@ func TestAppendBaseErrors(t *testing.T) {
 
 			merr, ok := result.(*oops.MultiError)
 			if !ok {
-				t.Errorf("Result was not oopsMultiError")
+				t.Errorf("Result was not oops.MultiError")
 			}
 
 			capturedErrors := merr.Errors()

--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -518,14 +518,14 @@ func TestFrames(t *testing.T) {
 			err:         chain(),
 			expected: [][]oops.Frame{
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 150, Reason: "a"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 518, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 999, Reason: "a"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 151, Reason: "b"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 518, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 999, Reason: "b"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""},
 				},
 			},
 		},
@@ -534,23 +534,23 @@ func TestFrames(t *testing.T) {
 			err:         oopsChain(),
 			expected: [][]oops.Frame{
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 141, Reason: "a"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 999, Reason: "a"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 142, Reason: "b"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 999, Reason: "b"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 144, Reason: "c"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""}},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 999, Reason: "c"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""}},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 145, Reason: "d"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 999, Reason: "d"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 999, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 999, Reason: ""},
 				},
 			},
 		},
@@ -565,7 +565,9 @@ func TestFrames(t *testing.T) {
 			for i, innerFrames := range frames {
 				newInnerFrames := make([]oops.Frame, len(innerFrames))
 				for j, actualFrame := range innerFrames {
-					newInnerFrames[j] = oops.Frame{File: stripPathPrefix(actualFrame.File), Line: actualFrame.Line, Function: actualFrame.Function, Reason: actualFrame.Reason}
+					// assert that we capture line numbers, unreliable to assert they exactly equal a value though
+					assert.Greater(t, actualFrame.Line, 0)
+					newInnerFrames[j] = oops.Frame{File: stripPathPrefix(actualFrame.File), Line: 999, Function: actualFrame.Function, Reason: actualFrame.Reason}
 				}
 				sanitizedFrames[i] = newInnerFrames
 			}

--- a/oops/oops_test.go
+++ b/oops/oops_test.go
@@ -518,13 +518,13 @@ func TestFrames(t *testing.T) {
 			err:         chain(),
 			expected: [][]oops.Frame{
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 144, Reason: "a"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 512, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 150, Reason: "a"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 518, Reason: ""},
 					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 110, Reason: "b"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 512, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.chain", Line: 151, Reason: "b"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 518, Reason: ""},
 					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
 				},
 			},
@@ -534,23 +534,23 @@ func TestFrames(t *testing.T) {
 			err:         oopsChain(),
 			expected: [][]oops.Frame{
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 100, Reason: "a"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 528, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 141, Reason: "a"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
 					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 101, Reason: "b"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 528, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 142, Reason: "b"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
 					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
 				},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 138, Reason: "c"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 528, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 144, Reason: "c"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
 					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""}},
 				{
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 139, Reason: "d"},
-					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 476, Reason: ""},
-					{File: "testing/testing.go", Function: "testing.tRunner", Line: 827, Reason: ""},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.oopsChain", Line: 145, Reason: "d"},
+					{File: "github.com/samsarahq/go/oops/oops_test.go", Function: "github.com/samsarahq/go/oops_test.TestFrames", Line: 534, Reason: ""},
+					{File: "testing/testing.go", Function: "testing.tRunner", Line: 1576, Reason: ""},
 				},
 			},
 		},
@@ -558,13 +558,18 @@ func TestFrames(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+
+			// we need to modify the returned errors to replace the actual paths to match the hard-coded test values
 			frames := oops.Frames(tc.err)
-			for _, framesInner := range frames {
-				for _, fr := range framesInner {
-					fr.File = stripPathPrefix(fr.File)
+			sanitizedFrames := make([][]oops.Frame, len(frames))
+			for i, innerFrames := range frames {
+				newInnerFrames := make([]oops.Frame, len(innerFrames))
+				for j, actualFrame := range innerFrames {
+					newInnerFrames[j] = oops.Frame{File: stripPathPrefix(actualFrame.File), Line: actualFrame.Line, Function: actualFrame.Function, Reason: actualFrame.Reason}
 				}
+				sanitizedFrames[i] = newInnerFrames
 			}
-			assert.Equal(t, tc.expected, frames)
+			assert.Equal(t, tc.expected, sanitizedFrames)
 		})
 	}
 }


### PR DESCRIPTION
Adding functionality heavily influenced by https://github.com/uber-go/multierr, ability to capture multiple errors and wrap each with tracebacks

adds a new public function `Append( error, error )` which returns a new error struct, works very similarly to the function in the uber lib linked above

