### PR TITLE
go snapshotter: Added a SnapshotFileName method

### DIFF
--- a/snapshotter/snapshotter.go
+++ b/snapshotter/snapshotter.go
@@ -116,6 +116,17 @@ func (s *Snapshotter) rewrite(name string) {
 	}
 }
 
+// Returns the name of the snapshot file that will/would be created when running Verify.
+// Includes the testdata/ path
+func (s *Snapshotter) SnapshotFileName() string {
+	s.t.Helper()
+	nameSuffix := ""
+	if s.name != "" {
+		nameSuffix = "_" + strings.Replace(strings.Replace(s.name, "/", "-", -1), ":", "-", -1)
+	}
+	return filepath.Join("testdata", strings.Replace(strings.Replace(s.t.Name(), "/", "-", -1), ":", "-", -1)+nameSuffix+".snapshots.json")
+}
+
 // Verify finishes a snapshot test. It either compares the test output, or it
 // rewrites the test output.
 func (s *Snapshotter) Verify() {
@@ -124,11 +135,7 @@ func (s *Snapshotter) Verify() {
 		s.t.Errorf("choose one of rewriteWithFailOnDiff and rewriteSnapshots, otherwise unexpected behavior can occur.")
 		return
 	}
-	nameSuffix := ""
-	if s.name != "" {
-		nameSuffix = "_" + strings.Replace(strings.Replace(s.name, "/", "-", -1), ":", "-", -1)
-	}
-	name := filepath.Join("testdata", strings.Replace(strings.Replace(s.t.Name(), "/", "-", -1), ":", "-", -1)+nameSuffix+".snapshots.json")
+	name := s.SnapshotFileName()
 	if isRewrite() {
 		s.rewrite(name)
 	} else {

--- a/snapshotter/snapshotter_test.go
+++ b/snapshotter/snapshotter_test.go
@@ -73,3 +73,18 @@ func TestSnapshotterInvalidFlags(t *testing.T) {
 		t.Errorf("expected error, got %v", m.errors)
 	}
 }
+
+func TestSnapshotFileName(t *testing.T) {
+	ss := snapshotter.New(t)
+	expected := fmt.Sprintf("testdata/%s.snapshots.json", t.Name())
+	if expected != ss.SnapshotFileName() {
+		t.Errorf("expected %s, got %s", expected, ss.SnapshotFileName())
+	}
+
+	ss2 := snapshotter.NewNamed(t, "foobar")
+	expected = fmt.Sprintf("testdata/%s_foobar.snapshots.json", t.Name())
+	if expected != ss2.SnapshotFileName() {
+		t.Errorf("expected %s, got %s", expected, ss2.SnapshotFileName())
+	}
+
+}


### PR DESCRIPTION
Dtest starts with an empty tmp directory for each test, which means snapshot files must be copied to devices to be able to use snapshot with dtests. Adding a SnapshotFileName method allows dtest to reliably get the path where the file should exist on the device. The files can then be uploaded (unless rewriting snapshots), Verify()'ed, and downloaded back to the original test host. 