### PR TITLE
snapshotter: expose global snapshotting configuration

### DIFF
--- a/snapshotter/snapshotter_test.go
+++ b/snapshotter/snapshotter_test.go
@@ -32,6 +32,10 @@ func (m *mockT) Errorf(format string, args ...interface{}) {
 	m.errors = append(m.errors, fmt.Sprintf(format, args...))
 }
 
+func (m *mockT) Error(args ...interface{}) {
+	m.errors = append(m.errors, fmt.Sprint(args...))
+}
+
 func TestSnapshotterFailed(t *testing.T) {
 	var m mockT
 	ss := snapshotter.New(&m)


### PR DESCRIPTION
snapshotter can run in a few different "modes" that determine whether it fails tests and/or rewrites snapshots. The mode can be configured by command-line arguments and/or environment variables, with some combinations of configuration being invalid. At Samsara, tooling and workflows are built around these mechanisms of global snapshot configuration to automate checks and make it easy for developers to update snapshots.

There are now some use-cases that require more advanced snapshotting behavior but similar configuration interfaces. To support these use-cases, this exposes the global configuration used by snapshotter. This will allow callers to implement custom snapshotting behavior while maintaining workflows consistent with the standard snapshotter.