### PR TITLE
oops: deprecate oops.Cause, oops.Is, oops.As

### DIFF
--- a/oops/oops.go
+++ b/oops/oops.go
@@ -447,8 +447,11 @@ func Wrapf(err error, format string, a ...interface{}) error {
 	return wrapf(err, fmt.Sprintf(format, a...))
 }
 
-// Cause extracts the cause error of an oops error. If err is not an oops
-// error, err itself is returned.
+// Deprecated: Use [errors.Is] or [errors.As] which are part of the standard library.
+//
+// Note that the behaviour of Cause differs from [errors.Is] and [errors.As]. Cause follows the error chain as long as the error is an oopsError. When a non oopsError is encountered, Cause returns the inner error of the oopsError. [errors.Is] and [errors.As] will follow the error chain until it finds an error that matches the target type.
+//
+// Cause extracts the cause error of an oops error. If err is not an oops error, err itself is returned.
 //
 // You can use Cause to check if an error is an expected error. For example, if
 // you know than EOF error is fine, you can handle it with Cause.

--- a/oops/xerrors.go
+++ b/oops/xerrors.go
@@ -40,6 +40,7 @@ type Wrapper interface {
 	Unwrap() error
 }
 
+// Deprecated: use [errors.Unwrap] which is part of the standard library.
 // Unwrap returns the result of calling the Unwrap method on err, if err implements
 // Unwrap. Otherwise, Unwrap returns nil.
 func Unwrap(err error) error {
@@ -50,6 +51,7 @@ func Unwrap(err error) error {
 	return u.Unwrap()
 }
 
+// Deprecated: use [errors.Is] which is part of the standard library.
 // Is reports whether any error in err's chain matches target.
 //
 // An error is considered to match a target if it is equal to that target or if
@@ -71,6 +73,7 @@ func Is(err, target error) bool {
 	}
 }
 
+// Deprecated: use [errors.As] which is part of the standard library.
 // As finds the first error in err's chain that matches the type to which target
 // points, and if so, sets the target to its value and returns true. An error
 // matches a type if it is assignable to the target type, or if it has a method


### PR DESCRIPTION
Deprecates `oops.Cause` in favour of the standard library `errors.Is` or `errors.As` functions. It also deprecates `oops.Is` and `oops.As` as they are just a copy of the standard library functions.