### PR TITLE
fix: don't strip 'src' from filepaths

### DIFF
--- a/oops/oops.go
+++ b/oops/oops.go
@@ -232,11 +232,6 @@ func framesWithSkipInfo(err error) ([][]Frame, []bool) {
 				break
 			}
 
-			i := strings.LastIndex(file, "/src/")
-			if i >= 0 {
-				file = file[i+len("/src/"):]
-			}
-
 			parsedFrames = append(parsedFrames, Frame{
 				File:     file,
 				Function: frame.Function,


### PR DESCRIPTION
Beginning with its initial commit (https://github.com/samsarahq/go/commit/237936dc7ac826df5f3cbb2d54e0ec6705060051)
8 years ago, `oops` strips anything up to and including a `/src/` from
filepaths in stack frames. For example, files like `go/foo/bar/src/baz/bim.go`
appear as `baz/bim.go` in stack frames.

In addition to being somewhat confusing and arbitrary (depending on
codebase/expections), this also seemingly breaks [Datadog source code
integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/);
Datadog is unable to use [git metadata](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=githubsaasonprem#embed-git-information-in-your-build-artifacts)
embeddd in telemetry to properly link to GitHub files.

This seeks to change that.

Signed-off-by: Mike Ball <mikedball@gmail.com>
